### PR TITLE
Update deprecated `load` call to `safe_load`

### DIFF
--- a/config.py
+++ b/config.py
@@ -26,7 +26,7 @@ def get_config(config_path=None):
 class Config:
     def __init__(self, config_yaml_path):
         with open(config_yaml_path) as fin:
-            config_data = yaml.load(fin)
+            config_data = yaml.safe_load(fin)
         missing = set(REQUIRED_CONFIG_KEYS) - set(config_data)
         if missing:
             raise ConfigError('Missing: {}'.format(sorted(missing)))

--- a/send_batch.py
+++ b/send_batch.py
@@ -41,7 +41,7 @@ for i in range(4, 0, -1):
     defaults_yaml_path = here.parents[i] / 'defaults.yaml'
     if defaults_yaml_path.is_file():
         with open(defaults_yaml_path) as f:
-            d = yaml.load(f)
+            d = yaml.safe_load(f)
         defaults.update(d)
 project_name = defaults['project_name']
 subproject_name = defaults['subproject_name']

--- a/tests/test_accept_batch.py
+++ b/tests/test_accept_batch.py
@@ -12,7 +12,7 @@ def test_fixture(accept_batch_fixture):
     for k in sorted(vars(accept_batch_fixture)):
         print(k, getattr(accept_batch_fixture, k))
     with open(accept_batch_fixture.root_dir.join('config.yaml')) as fin:
-        config = yaml.load(fin)
+        config = yaml.safe_load(fin)
     print()
     for k in sorted(config):
         print(k, config[k])

--- a/tests/test_send_batch.py
+++ b/tests/test_send_batch.py
@@ -17,7 +17,7 @@ def test_fixture(send_batch_fixture):
     for k in sorted(vars(send_batch_fixture)):
         print(k, getattr(send_batch_fixture, k))
     with open(send_batch_fixture.root_dir.join('config.yaml')) as fin:
-        config = yaml.load(fin)
+        config = yaml.safe_load(fin)
     print()
     for k in sorted(config):
         print(k, config[k])
@@ -62,7 +62,7 @@ def test_meta_yaml(ran_send_batch, yesterday_and_today):
     meta_path = ran_send_batch.batch_path/'meta.yaml'
     assert meta_path.isfile()
     with open(meta_path) as fin:
-        meta_dict = yaml.load(fin)
+        meta_dict = yaml.safe_load(fin)
     meta = Generic()
     meta.__dict__.update(meta_dict)
     assert meta.input == 'BioMe_batch24a_mplx.tsv'


### PR DESCRIPTION
Deprecated warning is now gone due to update
All test are now passing since a test for `send_batch` was picking up the warning.